### PR TITLE
Fix for compiling

### DIFF
--- a/HookRegistry/BackendSwitcher.cs
+++ b/HookRegistry/BackendSwitcher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using bgs;
 
 namespace Hooks
 {
@@ -18,9 +19,7 @@ namespace Hooks
 			string backend = Vars.Key("Aurora.Backend").GetStr("BattleNetDll");
 
 			IBattleNet impl;
-			if (backend == "BattleNetDll") {
-				impl = new BattleNetDll ();
-			} else if (backend == "BattleNetCSharp") {
+			if (backend == "BattleNetCSharp") {
 				impl = new BattleNetCSharp();
 			} else {
 				throw new NotImplementedException("Invalid Battle.net Backend (Aurora.Backend)");

--- a/HookRegistry/UseWebAuth.cs
+++ b/HookRegistry/UseWebAuth.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using bgs;
 
 namespace Hooks
 {


### PR DESCRIPTION
UnityHook won't compile as it stands (at least in Visual Studio 2015 with Hearthstone patch 4.2). This PR enables it to compile and run.

Katy.
