### PR TITLE
Add Windows helper bootstrapper

### DIFF
--- a/Hooker/Hooker.csproj
+++ b/Hooker/Hooker.csproj
@@ -54,9 +54,18 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="example_hooks" />
+    <None Include="bootstrap.bat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="example_hooks">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Hooker/bootstrap.bat
+++ b/Hooker/bootstrap.bat
@@ -1,0 +1,58 @@
+@echo off
+
+rem Usage: bootstrap [path to game] [path to hook file]
+
+set GAME_FOLDER="%ProgramFiles(x86)%\Battle.net\Hearthstone"
+set HOOKS="%CD%\example_hooks"
+
+if "%~1"=="" (
+	echo No game folder supplied - using default: %GAME_FOLDER%
+) else (
+	set GAME_FOLDER="%~1"
+)
+
+if "%~2"=="" (
+	echo No hook file supplied - using default: %HOOKS%
+) else (
+	set HOOKS="%~2"
+)
+
+if not exist %GAME_FOLDER% (
+	echo Could not find game folder: %GAME_FOLDER%
+	exit /B 1
+)
+
+if not exist %GAME_FOLDER%\Hearthstone_Data\Managed\Assembly-CSharp.dll (
+	echo Game folder did not contain game DLLs: %GAME_FOLDER%
+	exit /B 1
+)
+
+if not exist %HOOKS% (
+	echo Could not find hooks file: %HOOKS%
+	exit /B 1
+)
+
+echo Preparing...
+
+rem Backup existing DLLs
+copy /y %GAME_FOLDER%\Hearthstone_Data\Managed\Assembly-CSharp.dll %GAME_FOLDER%\Hearthstone_Data\Managed\Assembly-CSharp.dll.previous >nul
+copy /y %GAME_FOLDER%\Hearthstone_Data\Managed\Assembly-CSharp-firstpass.dll %GAME_FOLDER%\Hearthstone_Data\Managed\Assembly-CSharp-firstpass.dll.previous >nul
+
+rem Place the original DLLs (from our lib folder) in the game folder
+copy /y Assembly-CSharp.dll %GAME_FOLDER%\Hearthstone_Data\Managed >nul
+copy /y Assembly-CSharp-firstpass.dll %GAME_FOLDER%\Hearthstone_Data\Managed >nul
+
+rem Save the original DLLs in the game folder too just for clarity
+copy /y %GAME_FOLDER%\Hearthstone_Data\Managed\Assembly-CSharp.dll %GAME_FOLDER%\Hearthstone_Data\Managed\Assembly-CSharp.dll.original >nul
+copy /y %GAME_FOLDER%\Hearthstone_Data\Managed\Assembly-CSharp-firstpass.dll %GAME_FOLDER%\Hearthstone_Data\Managed\Assembly-CSharp-firstpass.dll.original >nul
+
+rem Modify DLLs
+
+echo Hooking...
+
+Hooker %GAME_FOLDER%\Hearthstone_Data %HOOKS% >nul
+
+echo Done.
+echo.
+echo Original DLLs at: %GAME_FOLDER%\Hearthstone_Data\Managed\*.dll.original
+echo Previous DLLs at: %GAME_FOLDER%\Hearthstone_Data\Managed\*.dll.previous


### PR DESCRIPTION
This commit adds a tool to help streamline your workflow when making many hooks/DLL edits on Windows.

The bootstrap.bat is added. It is invoked as follows:

bootstrap [path_to_game] [hook_file]

Both arguments are optional. If not supplied, the script will use example_hooks and the default installation directory for Hearthstone.

The script:
1. Checks that the game folder exists and contains the expected DLLs
2. Checks that the hook file exists
3. Makes a backup of the current game DLLs as *.dll.previous in the same folder
4. Copies the DLLs from $(SolutionDir)\lib as *.dll.original in the game folder for quick recovery
5. Restores the original game DLLs before hooking*
6. Runs Hooker
- Step 5 is the crucial work. It ensures that the user doesn't accidentally hook already-hooked files, which is a problem with Hooker as it stands if the user runs it more than once without restoring the original DLLs first. Hooking already hooked files leads to unpredictable behaviour in the game client. The bootstrap script ensures the user is always operating on the original DLLs.

Previous workflow (before this commit):
1. Build Hooker
2. Restore original DLLs with Windows Explorer
3. Backup existing hooked DLLs if needed
4. Open a prompt
5. Type 'hooker c:\program files (x86)\battle.net\hearthstone\hearthstone_data ....\example_hooks'

New workflow (after this commit):
1. Build Hooker
2. Open a prompt
3. Type bootstrap
