### PR TITLE
Restored macOS support

### DIFF
--- a/Hooker/src/Program.cs
+++ b/Hooker/src/Program.cs
@@ -11,8 +11,11 @@ namespace Hooker
     {
         // This path element will be added to the `gamedir` option.
         // In case the necessary libraries are not located in the root directory of the game folder.
-        // The Unity libraries are located at "Hearthstone_Data\Managed", from the root of HS install folder
-        public const string REL_LIBRARY_PATH = "Hearthstone_Data\\Managed";
+        // The Unity libraries are located at "Hearthstone_Data\Managed", from the root of HS install folder on Windows
+		// And in Contents/Resources/Data/Managed on macOS
+        public const string WIN_REL_LIBRARY_PATH = "Hearthstone_Data\\Managed";
+		public const string MAC_REL_LIBRARY_PATH = "Contents/Resources/Data/Managed";
+
 
         // Operation verbs
         public const string OPERATION_HOOK = "hook";
@@ -32,8 +35,17 @@ namespace Hooker
 
             // Check the game path
             var gamePath = Path.GetFullPath(options.GamePath);
+
             // Append relative directory to library files
-            gamePath = Path.Combine(gamePath, REL_LIBRARY_PATH);
+			int p = (int)Environment.OSVersion.Platform;
+			if ((p == 4) || (p == 6) || (p == 128)) {
+				// Running macOS
+				gamePath = Path.Combine (gamePath, MAC_REL_LIBRARY_PATH);
+			} else {
+				// Running Windows
+				gamePath = Path.Combine (gamePath, WIN_REL_LIBRARY_PATH);
+			}
+
             options.GamePath = gamePath;
             if (!Directory.Exists(gamePath))
             {


### PR DESCRIPTION
It was "broken" because the game-path that was hardcoded was meant for Windows. I added the path for macOS and a check.